### PR TITLE
Fix a problem that does not work on Redmine3

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 # Plugin's routes
 # See: http://guides.rubyonrails.org/routing.html
 Rails.application.routes.draw do
-  match 'news_notifications/:action', :to => 'news_notifications'
+  get 'news_notifications/:action', :to => 'news_notifications'
 end


### PR DESCRIPTION
Not available the `match` method in router without specifying an HTTP method, on Rails4.

Redmine3ではRails4が使われていますが、Rails4では`match`メソッドがそのまま使えないので、`get`を指定するように変更しました。
